### PR TITLE
Add current cost and parking duration when parking session starts

### DIFF
--- a/app/src/main/java/com/cpen391/hardwareapp/Constants.java
+++ b/app/src/main/java/com/cpen391/hardwareapp/Constants.java
@@ -4,9 +4,10 @@ public class Constants {
     // Message types sent from the BluetoothChatService Handler
     public static final int MESSAGE_READ = 2;
 
-    // Key names received from the BluetoothChatService Handler
     public static final String DEVICE_NAME = "device_name";
     public static final String TOAST = "toast";
+    public static final int unitPrice = 12;
+    public static final String unitPriceStr = "unitPrice";
 
     public static final String plateNo = "plateNo";
     public static final String CONFIRM_FALSE = "CONFIRM,FALSE,";
@@ -18,4 +19,6 @@ public class Constants {
     public static final String USER = "USER";
     public static final String OK = "OK";
     public static final String CONFIRM = "CONFIRM";
+    public static final String LEAVE = "LEAVE";
+
 }

--- a/app/src/main/java/com/cpen391/hardwareapp/MainActivity.java
+++ b/app/src/main/java/com/cpen391/hardwareapp/MainActivity.java
@@ -11,6 +11,7 @@ import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothSocket;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
@@ -42,7 +43,7 @@ public class MainActivity extends AppCompatActivity {
      *       Modify logic if tablet will be paired with more than one device,
      *       and we need to specify which one to connect with
      * */
-
+    public static SharedPreferences sp;
     private final static int REQUEST_ENABLE_BT = 1;
     private BluetoothAdapter mBluetoothAdapter;
     private Context context;
@@ -70,6 +71,8 @@ public class MainActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+        sp = getSharedPreferences("meter",MODE_PRIVATE);
+        sp.edit().putInt(Constants.unitPriceStr, Constants.unitPrice).apply();
 
         NavController navController = Navigation.findNavController(this, R.id.navHostFragment);
         context = getApplicationContext();

--- a/app/src/main/java/com/cpen391/hardwareapp/OccupiedFragment.java
+++ b/app/src/main/java/com/cpen391/hardwareapp/OccupiedFragment.java
@@ -6,7 +6,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.navigation.NavController;
 import androidx.navigation.Navigation;
-
 import android.os.Handler;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -84,7 +83,9 @@ public class OccupiedFragment extends btFragment {
     public static String calcCost(int unitPrice, String duration) {
         String delims = "[:]";
         String[] tokens = duration.split(delims);
-        double timeHr = Math.ceil(Double.parseDouble(tokens[0]) + (Double.parseDouble(tokens[1])/60));
+        
+        /* +1 minute takes care of case when parking session is in the first minute of the hour (like 00:00:30), this already counts as parking for the hour */
+        double timeHr = Math.ceil(Double.parseDouble(tokens[0]) + ((Double.parseDouble(tokens[1]) + 1)/60));
         return(String.format("%.2f", timeHr*unitPrice));
     }
 }

--- a/app/src/main/java/com/cpen391/hardwareapp/OccupiedFragment.java
+++ b/app/src/main/java/com/cpen391/hardwareapp/OccupiedFragment.java
@@ -2,14 +2,15 @@ package com.cpen391.hardwareapp;
 
 import android.os.Bundle;
 
-import androidx.fragment.app.Fragment;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.navigation.NavController;
 import androidx.navigation.Navigation;
 
+import android.os.Handler;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Button;
 import android.widget.TextView;
 
 public class OccupiedFragment extends btFragment {
@@ -22,11 +23,39 @@ public class OccupiedFragment extends btFragment {
         // Inflate the layout for this fragment
         v =  inflater.inflate(R.layout.fragment_occupied, container, false);
         plateNo = getArguments().getString(Constants.plateNo);
-
         TextView plateNoText = v.findViewById(R.id.PlateNumber);
         plateNoText.setText(plateNo);
 
         return v;
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState){
+        super.onViewCreated(view, savedInstanceState);
+        TextView duration = v.findViewById(R.id.duration);
+        TextView cost = v.findViewById(R.id.cost);
+
+        /* Start a timer to keep track of current parking session tme*/
+        long startTime = System.currentTimeMillis();
+        Handler timerHandler = new Handler();
+        Runnable timerRunnable = new Runnable() {
+
+            @Override
+            public void run() {
+                /* Calculate parking session duration */
+                long millis = System.currentTimeMillis() - startTime;
+                int seconds = (int) (millis / 1000) %60;
+                int minutes = (int) (millis/(1000 * 60)%60);
+                int hours = (int) (millis/(1000 * 60 * 60));
+                String durationStr = String.format("%02d", hours)+ ":" + String.format("%02d", minutes);
+
+                /* Update displayed timer and re-calculate cost */
+                duration.setText(durationStr);
+                cost.setText(calcCost(MainActivity.sp.getInt(Constants.unitPriceStr,0), durationStr));
+                timerHandler.postDelayed(this, 30000);
+            }
+        };
+        timerHandler.postDelayed(timerRunnable, 0);
     }
 
 
@@ -39,11 +68,23 @@ public class OccupiedFragment extends btFragment {
     @Override
     public void readBtData(String msg) {
         String[] strArray = msg.split(",", 2);
-        if (strArray[0].equals(Constants.END)){
+        if (strArray[0].equals(Constants.OK)){
             final NavController navController = Navigation.findNavController(v);
-            if(strArray[1].equals(plateNo)) {
+            if(strArray[1].equals(Constants.LEAVE)) {
                 navController.navigate(R.id.action_occupiedFragment_to_initialFragment);
             }
         }
+    }
+
+    /**
+     * Calculate cost based on the given unit price and parking duration
+     * Round up to the nearest hour
+     * Return a string with the cost formatted up to 2 decimal places X.XX
+     */
+    public static String calcCost(int unitPrice, String duration) {
+        String delims = "[:]";
+        String[] tokens = duration.split(delims);
+        double timeHr = Math.ceil(Double.parseDouble(tokens[0]) + (Double.parseDouble(tokens[1])/60));
+        return(String.format("%.2f", timeHr*unitPrice));
     }
 }

--- a/app/src/main/java/com/cpen391/hardwareapp/OccupiedFragment.java
+++ b/app/src/main/java/com/cpen391/hardwareapp/OccupiedFragment.java
@@ -46,12 +46,12 @@ public class OccupiedFragment extends btFragment {
                 int seconds = (int) (millis / 1000) %60;
                 int minutes = (int) (millis/(1000 * 60)%60);
                 int hours = (int) (millis/(1000 * 60 * 60));
-                String durationStr = String.format("%02d", hours)+ ":" + String.format("%02d", minutes);
+                String durationStr = String.format("%02d", hours)+ ":" + String.format("%02d", minutes)+ ":" + String.format("%02d", seconds);
 
                 /* Update displayed timer and re-calculate cost */
                 duration.setText(durationStr);
                 cost.setText(calcCost(MainActivity.sp.getInt(Constants.unitPriceStr,0), durationStr));
-                timerHandler.postDelayed(this, 30000);
+                timerHandler.postDelayed(this, 1000);
             }
         };
         timerHandler.postDelayed(timerRunnable, 0);
@@ -83,7 +83,7 @@ public class OccupiedFragment extends btFragment {
     public static String calcCost(int unitPrice, String duration) {
         String delims = "[:]";
         String[] tokens = duration.split(delims);
-        
+
         /* +1 minute takes care of case when parking session is in the first minute of the hour (like 00:00:30), this already counts as parking for the hour */
         double timeHr = Math.ceil(Double.parseDouble(tokens[0]) + ((Double.parseDouble(tokens[1]) + 1)/60));
         return(String.format("%.2f", timeHr*unitPrice));

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -21,7 +21,6 @@
             android:layout_height="wrap_content"
             android:layout_marginLeft="10dp"
             android:layout_marginTop="20dp"
-            android:layout_marginBottom="5dp"
             android:fontFamily="@font/aldrich"
             android:text="SmartMetr"
             android:textColor="@color/headerText"
@@ -29,8 +28,7 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="10dp"
-            android:layout_marginBottom="10dp"
+            android:layout_marginTop="5dp"
             android:elevation="5dp"
             android:orientation="horizontal">
             <TextView
@@ -50,6 +48,33 @@
                 android:layout_marginLeft="10dp"
                 android:fontFamily="@font/aldrich"
                 android:text="100001"
+                android:textColor="@color/headerText"
+                android:textSize="20dp" />
+        </LinearLayout>
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="10dp"
+            android:elevation="5dp"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/CostHeader"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="10dp"
+                android:fontFamily="@font/aldrich"
+                android:text="Cost (per Hr): $"
+                android:textColor="@color/headerText"
+                android:textSize="20dp" />
+
+            <TextView
+                android:id="@+id/unitPrice"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="10dp"
+                android:fontFamily="@font/aldrich"
+                android:text="12"
                 android:textColor="@color/headerText"
                 android:textSize="20dp" />
         </LinearLayout>

--- a/app/src/main/res/layout/fragment_occupied.xml
+++ b/app/src/main/res/layout/fragment_occupied.xml
@@ -10,7 +10,7 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_weight="4"
+        android:layout_weight="5.5"
         android:orientation="horizontal"
         android:gravity="center">
     </LinearLayout>
@@ -18,33 +18,66 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_weight="1"
         android:orientation="horizontal"
-        android:gravity="center">
+        android:gravity="center"
+        android:layout_weight="0.5"
+        android:layout_margin="10dp">
         <TextView
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:text="OCCUPIED"
             android:gravity="center"
-            android:textSize="60dp"
-
+            android:textSize="50dp"
             android:textColor="@color/red"
             android:textStyle="bold"/>
+
+    </LinearLayout>
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center">
+        <TextView
+            android:id="@+id/duration"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:text="HH:MM:SS"
+            android:gravity="center"
+            android:textSize="35dp"
+            android:textStyle="bold"/>
+
+    </LinearLayout>
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center">
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="$"
+            android:gravity="center"
+            android:textSize="35dp" />
+        <TextView
+            android:id="@+id/cost"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="12"
+            android:gravity="center"
+            android:textSize="35dp" />
 
     </LinearLayout>
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_weight="0"
         android:orientation="horizontal"
-        android:layout_margin="10dp">
+        android:layout_marginTop="10dp">
 
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
-            android:layout_margin="8dp"
-            android:layout_weight="1"
+            android:layout_weight="0.5"
             android:text="License Plate"
             android:textSize="30dp"
             android:gravity="center"/>
@@ -55,17 +88,17 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        android:layout_margin="8dp"
-        android:layout_gravity="center">
+        android:layout_gravity="center"
+        android:layout_margin="5dp">
 
         <TextView
             android:id="@+id/PlateNumber"
-            android:layout_width="279dp"
+            android:layout_width="wrap_content"
             android:layout_height="match_parent"
-            android:layout_weight="2"
+            android:layout_weight="1"
             android:gravity="center"
             android:text="ABC123"
-            android:textSize="60dp" />
+            android:textSize="40dp" />
 
     </LinearLayout>
 
@@ -74,7 +107,9 @@
         android:layout_height="wrap_content"
         android:layout_weight="1"
         android:orientation="horizontal"
-        android:gravity="center"/>
+        android:gravity="center">
+    </LinearLayout>
+
 
 
 </LinearLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -60,7 +60,8 @@
         android:id="@+id/occupiedFragment"
         android:name="com.cpen391.hardwareapp.OccupiedFragment"
         android:label="fragment_occupied"
-        tools:layout="@layout/fragment_occupied" >
+        tools:layout="@layout/fragment_occupied"
+        app:startDestination="@id/action_occupiedFragment_to_initialFragment">
         <action
             android:id="@+id/action_occupiedFragment_to_initialFragment"
             app:destination="@id/initialFragment" />


### PR DESCRIPTION
# :ship: Pull Request

## :question: Purpose

- Add a display of the current cost and parking duration (HH:MM:SS) to the occupied fragment (when the parking session has been fully initialized)
     - added a local timer to keep track of the start time and use the default unit price to calculate the current cost
     - Since we are rounding up to the nearest Hour, the cost would 
- Modified the message expected when the parking session ends from "END,licensePlate" to "OK,LEAVE"

## :hammer: Validation Strategy

Connect with Bluetooth to test the hardware app functionality
When a parking session has been successfully started, verify that the timer is updated every second, and hourly cost is updated each hour

