### PR TITLE
Timeout for user confirmation

### DIFF
--- a/app/src/main/java/com/cpen391/hardwareapp/Constants.java
+++ b/app/src/main/java/com/cpen391/hardwareapp/Constants.java
@@ -8,14 +8,15 @@ public class Constants {
     public static final String TOAST = "toast";
     public static final int unitPrice = 12;
     public static final String unitPriceStr = "unitPrice";
+    public static final String counterTimerInMilli = "counterTimerInMilli";
 
     public static final String plateNo = "plateNo";
     public static final String CONFIRM_FALSE = "CONFIRM,FALSE,";
-    public static final String CONFIRM_NEW = "CONFIRM,NEW,";
     public static final String CONFIRM_TRUE = "CONFIRM,TRUE,";
+    public static final String CONFIRM_TIMEOUT = "CONFIRM,TIMEOUT";
     public static final String PAYMENT = "PAYMENT,";
+    public static final String PAYMENT_TIMEOUT = "PAYMENT,TIMEOUT";
     public static final String DONE = "DONE";
-    public static final String END = "END";
     public static final String USER = "USER";
     public static final String OK = "OK";
     public static final String CONFIRM = "CONFIRM";

--- a/app/src/main/java/com/cpen391/hardwareapp/InitialFragment.java
+++ b/app/src/main/java/com/cpen391/hardwareapp/InitialFragment.java
@@ -29,15 +29,6 @@ public class InitialFragment extends btFragment{
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState){
         super.onViewCreated(view, savedInstanceState);
         final NavController navController = Navigation.findNavController(v);
-
-        /* User Manually starting parking instance */
-        Button enterBtn = v.findViewById(R.id.EnterBtn);
-        enterBtn.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                navController.navigate(R.id.action_initialFragment_to_plateFragment);
-            }
-        });
     }
 
     /**

--- a/app/src/main/java/com/cpen391/hardwareapp/MainActivity.java
+++ b/app/src/main/java/com/cpen391/hardwareapp/MainActivity.java
@@ -209,5 +209,11 @@ public class MainActivity extends AppCompatActivity {
             btThread.WriteToBTDevice(msg);
         }
     }
+
+    /* disable using back button on this app */
+    @Override
+    public void onBackPressed() {
+
+    }
 }
 

--- a/app/src/main/res/layout/fragment_initial.xml
+++ b/app/src/main/res/layout/fragment_initial.xml
@@ -33,41 +33,11 @@
 
     </LinearLayout>
 
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:gravity="center">
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:text="Are You Parking Here?"
-            android:gravity="center_horizontal"
-            android:textSize="30dp"
-
-/>
-
-    </LinearLayout>
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_weight="0"
-        android:orientation="horizontal"
-        android:gravity="center">
-
-        <Button
-            android:id="@+id/EnterBtn"
-            style="@style/Widget.AppCompat.Button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="ENTER PLATE NUMBER"
-            android:layout_margin="20dp"
-            android:textSize="30dp"/>
-    </LinearLayout>
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_weight="0.5"
+        android:layout_weight="1.5"
         android:orientation="horizontal"
         android:gravity="center"/>
 

--- a/app/src/main/res/layout/fragment_occupied.xml
+++ b/app/src/main/res/layout/fragment_occupied.xml
@@ -41,7 +41,7 @@
             android:id="@+id/duration"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:text="HH:MM:SS"
+            android:text="00:01:35"
             android:gravity="center"
             android:textSize="35dp"
             android:textStyle="bold"/>
@@ -62,7 +62,7 @@
             android:id="@+id/cost"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="12"
+            android:text="12.00"
             android:gravity="center"
             android:textSize="35dp" />
 

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -10,9 +10,6 @@
         android:label="fragment_initial"
         tools:layout="@layout/fragment_initial" >
         <action
-            android:id="@+id/action_initialFragment_to_plateFragment"
-            app:destination="@id/plateFragment" />
-        <action
             android:id="@+id/action_initialFragment_to_detectFragment"
             app:destination="@id/detectFragment" />
     </fragment>
@@ -31,6 +28,9 @@
             android:name="plateNo"
             app:argType="string"
             app:nullable="true" />
+        <action
+            android:id="@+id/action_plateFragment_to_initialFragment"
+            app:destination="@id/initialFragment" />
     </fragment>
     <fragment
         android:id="@+id/paymentFragment"
@@ -40,6 +40,9 @@
         <action
             android:id="@+id/action_paymentFragment_to_occupiedFragment"
             app:destination="@id/occupiedFragment" />
+        <action
+            android:id="@+id/action_paymentFragment_to_initialFragment"
+            app:destination="@id/initialFragment" />
     </fragment>
     <fragment
         android:id="@+id/detectFragment"
@@ -55,6 +58,9 @@
         <action
             android:id="@+id/action_detectFragment_to_paymentFragment"
             app:destination="@id/paymentFragment" />
+        <action
+            android:id="@+id/action_detectFragment_to_initialFragment"
+            app:destination="@id/initialFragment" />
     </fragment>
     <fragment
         android:id="@+id/occupiedFragment"


### PR DESCRIPTION
# :ship: Pull Request

## :question: Purpose

- Add a 2-minute timeout when the app is waiting for user input (for confirming/updating plate number or for entering payment info)
     - If the timer is up, and the user didn't submit their changes, then the app will cancel the transaction (send a TIMEOUT message to the DE1) and return to the initial screen.

- Remove license plate input option.

## :hammer: Validation Strategy

Requires Bluetooth to test. 
- Verify that after a parking session was started, if the user does not confirm their license plate (or submit their modified plate number) within 2 minutes, the app will send `CONFIRM,TIMEOUT` to the De1 and end the parking session
- Verify that after 2 minutes of the app transitioning to the payment fragment, if the user does not submit their payment information, the app will send `PAYMENT,TIMEOUT` to the De1 and end the parking session. 

