### PR TITLE
Pairing to RFS Device

### DIFF
--- a/app/src/main/java/com/cpen391/hardwareapp/Constants.java
+++ b/app/src/main/java/com/cpen391/hardwareapp/Constants.java
@@ -21,5 +21,5 @@ public class Constants {
     public static final String OK = "OK";
     public static final String CONFIRM = "CONFIRM";
     public static final String LEAVE = "LEAVE";
-
+    public static final String BLUETOOTH_DEVICE_NAME_RFS = "hc01.com HC-05";
 }

--- a/app/src/main/java/com/cpen391/hardwareapp/MainActivity.java
+++ b/app/src/main/java/com/cpen391/hardwareapp/MainActivity.java
@@ -141,11 +141,25 @@ public class MainActivity extends AppCompatActivity {
                 Paireddevices.add(aNewdevice);
             }
 
-            if(Paireddevices.size()> 1){
-                Toast.makeText(context, "More than one device paired, connecting to the first one", Toast.LENGTH_LONG).show();
+            BluetoothDevice HCDevice = null;
+            if(Paireddevices.size() == 0) {
+                Toast.makeText(context, "No paired Devices. Will fail.", Toast.LENGTH_LONG).show();
             }
+
+            for (BluetoothDevice elem : Paireddevices) {
+                if (elem.getName().equals(Constants.BLUETOOTH_DEVICE_NAME_RFS)) {
+                    HCDevice = elem;
+                    break;
+                }
+            }
+
+            if (HCDevice == null) {
+                Toast.makeText(context, "Could not find RFS Bluetooth pairing, using first paired device.", Toast.LENGTH_LONG).show();
+                HCDevice = Paireddevices.get(0);
+            }
+
             /* connect to first paired device */
-            CreateSerialBluetoothDeviceSocket(Paireddevices.get(0));
+            CreateSerialBluetoothDeviceSocket(HCDevice);
             ConnectToSerialBlueToothDevice();
 
             /* Start bluetooth thread */


### PR DESCRIPTION
# :ship: Pull Request

## :question: Purpose

In the case where there are multiple paired devices, this change will look for the one corresponding to the RFS Bluetooth adapter. If it can't find it, it will just default to the first device (as it did before).

## :hammer: Validation Strategy

Tried on device with multiple paired devices with one of them being the RFS board.

## :tickets: Ticket(s)

Affects #

(Create a copy of that line for each Github Issue affected,
and replace "Affects" with "Closes" if merging this will close the relevant ticket.)
