### PR TITLE
Fix Bluetooth comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CPEN 391 User App
+# CPEN 391 Hardware App
 
 ![Build](https://github.com/rmcreyes/cpen391-hardware-app/workflows/Build/badge.svg)
 

--- a/app/src/main/java/com/cpen391/hardwareapp/OccupiedFragment.java
+++ b/app/src/main/java/com/cpen391/hardwareapp/OccupiedFragment.java
@@ -60,7 +60,7 @@ public class OccupiedFragment extends btFragment {
 
     /**
      * Received data from the DE1
-     * We are expecting a string in the format "END,ABCABC" where ABCABC is the plate number
+     * We are expecting a string in the format "OK,LEAVE"
      *
      * Messages in any other formats are ignored
      */


### PR DESCRIPTION
# :ship: Pull Request

## :question: Purpose

Fix the comments on the Bluetooth message to the app is expecting when the parking session ends, from "END,PlateNo" to  "OK,LEAVE"

## :hammer: Validation Strategy
N/A

